### PR TITLE
feat/build-only-push-or-pr: Build only on PR or push

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -2,7 +2,7 @@ name: Build workflow
 on:
   push:
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Build and publish should be triggered only once if the PR and push are done from/onto the same branch